### PR TITLE
Chat options, remove stickers, restrict user to send stickers

### DIFF
--- a/.chatlist.example.json
+++ b/.chatlist.example.json
@@ -1,3 +1,10 @@
 {
-  "IT Holywars": -1001095675733
+  "IT Holywars": {
+    "id": -1001095675733,
+    "stickers": {
+      "remove": true,
+      "restrict": true
+    }
+  },
+  "Another Chat without settings": -100
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "json.schemas": [
+    {
+      "fileMatch": [
+        ".chatlist.json",
+        ".chatlist.example.json"
+      ],
+      "url": "./chatlist.schema.json"
+    }
+  ]
+}

--- a/chatlist.schema.json
+++ b/chatlist.schema.json
@@ -1,0 +1,40 @@
+{
+  "type": "object",
+  "patternProperties": {
+    ".*": {
+      "oneOf": [
+          { "$ref": "#/definitions/chatId" },
+          { "$ref": "#/definitions/chatConfig" }
+      ]
+    }
+  },
+  "definitions": {
+    "chatId": {
+      "type": "number"
+    },
+    "chatConfig": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "number"
+        },
+        "stickers": {
+          "type": "object",
+          "properties": {
+            "remove": {
+              "description": "Auto remove stickers from chat",
+              "type": "boolean",
+              "default": false
+            },
+            "restrict": {
+              "description": "Restrict users to send stickers",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "sinon": "^4.1.3"
   },
   "dependencies": {
+    "ajv": "^5.5.2",
     "botanio": "0.0.6",
     "debug": "^3.1.0",
     "dotenv": "^4.0.0",

--- a/src/features/bot-participation/index.js
+++ b/src/features/bot-participation/index.js
@@ -43,14 +43,24 @@ async function onNewChatMembers(ctx) {
  * - Remove sticker
  * - Restrict user to send stickers
  */
-async function handleStickerSend({ message, chat, getChat, deleteMessage }) {
+async function handleStickerSend({ message, chat, from, getChat, deleteMessage }) {
   debug('handleStickerSend', message)
-  const stickersOptions = getChat(chat.id).getStickersOptions()
+  const chatInstance = getChat(chat.id)
+  const stickersOptions = chatInstance.getStickersOptions()
 
-  console.log(stickersOptions)
   if (stickersOptions.remove) {
-    debug('handleStickerSend:removeSticker')
-    debug('deleteMessage', await deleteMessage())
+    debug('handleStickerSend:removeSticker', await deleteMessage())
+  }
+
+  if (stickersOptions.restrict) {
+    debug('handleStickerSend:restrictUser')
+    await chatInstance.restrictMember(from, {
+      // TODO(ssova): get member settings and merge it
+      can_send_messages: true,
+      can_send_media_messages: true,
+      can_add_web_page_previews: true,
+      can_send_other_messages: false,
+    })
   }
 }
 

--- a/src/features/bot-participation/index.js
+++ b/src/features/bot-participation/index.js
@@ -1,4 +1,5 @@
 const debug = require('debug')('rubot:features:botparticipation:index')
+const { allowWhiteListChat } = require('../../middlewares/allowed-chat')
 // const text = require('../../text')
 
 /**
@@ -37,9 +38,26 @@ async function onNewChatMembers(ctx) {
   }
 }
 
+/**
+ * Check each sticker and check options
+ * - Remove sticker
+ * - Restrict user to send stickers
+ */
+async function handleStickerSend({ message, chat, getChat, deleteMessage }) {
+  debug('handleStickerSend', message)
+  const stickersOptions = getChat(chat.id).getStickersOptions()
+
+  console.log(stickersOptions)
+  if (stickersOptions.remove) {
+    debug('handleStickerSend:removeSticker')
+    debug('deleteMessage', await deleteMessage())
+  }
+}
+
 
 function featureBotParticipation(bot) {
   bot.on('new_chat_members', onNewChatMembers)
+  bot.on('sticker', allowWhiteListChat, handleStickerSend)
 }
 
 module.exports = featureBotParticipation

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,13 @@ const config = require('./config')
 const { sequelize } = require('./models')
 const { createBot } = require('./lib/runtime')
 const { Channel } = require('./lib/channel')
+const { InvalidChatlistError, validateChatList, normalizeChatList } = require('./lib/chatlist-validate')
 const { elasticPing } = require('./lib/elastic')
 const features = require('./features')
 
 
 let CHAT_LIST
-
+/* eslint-disable unicorn/no-process-exit, no-console */
 
 if (!config.bot.token) {
   throw new Error('No telegram bot token provided')
@@ -19,13 +20,19 @@ if (!config.bot.token) {
 try {
   const obj = require('../.chatlist.json') // eslint-disable-line global-require
 
-  CHAT_LIST = [...Object.values(obj)]
+  validateChatList(obj)
+  CHAT_LIST = [...Object.values(normalizeChatList(obj))]
 }
 catch (error) {
   if (error.code === 'MODULE_NOT_FOUND') {
-    // eslint-disable-next-line no-console
     console.log('ERROR: Maybe you forget create .chatlist.json ?')
-    process.exit(-1) // eslint-disable-line unicorn/no-process-exit
+    process.exit(-1)
+  }
+
+  if (error instanceof InvalidChatlistError) {
+    console.error(error.message)
+    console.error(error.stack)
+    process.exit(-1)
   }
 
   throw error
@@ -55,10 +62,11 @@ async function main() {
     throw new Error('Bot should be admin and can post messages to private channel')
   }
 
-  await Promise.all(CHAT_LIST.map((id) => {
-    debug(`Create chat instance for id:${id}`)
-    const chat = bot.context.getChat(id)
+  await Promise.all(CHAT_LIST.map((options) => {
+    debug(`Create chat instance for id:${options.id}`)
+    const chat = bot.context.getChat(options.id)
 
+    chat.setOptions(options)
     bot.context.ownedChats.push(chat)
     return chat.getAdmins()
   }))

--- a/src/index.js
+++ b/src/index.js
@@ -18,10 +18,10 @@ if (!config.bot.token) {
 }
 
 try {
-  const obj = require('../.chatlist.json') // eslint-disable-line global-require
+  const chatlistConfig = require('../.chatlist.json') // eslint-disable-line global-require
 
-  validateChatList(obj)
-  CHAT_LIST = [...Object.values(normalizeChatList(obj))]
+  validateChatList(chatlistConfig)
+  CHAT_LIST = [...Object.values(normalizeChatList(chatlistConfig))]
 }
 catch (error) {
   if (error.code === 'MODULE_NOT_FOUND') {

--- a/src/lib/chatlist-validate.js
+++ b/src/lib/chatlist-validate.js
@@ -1,0 +1,55 @@
+const Ajv = require('ajv')
+const schema = require('../../chatlist.schema')
+
+
+const ajv = new Ajv()
+const validate = ajv.compile(schema)
+
+class InvalidChatlistError extends TypeError {
+  constructor(message, errors) {
+    super(message)
+    this.name = 'InvalidChatlistError'
+    this.stack = errors.reverse()
+      .map(error => `${error.dataPath} ${error.message}`)
+      .join('\n')
+  }
+}
+
+
+function validateChatList(list) {
+  if (!validate(list)) {
+    throw new InvalidChatlistError('Invalid .chatlist.json file', validate.errors)
+  }
+}
+
+/**
+ * Convert object of chat id and chat options to chat options
+ *
+ * Important! Thit function must be in sync with chatlist.schema.json
+ * @param {{}} list
+ * @return {{}}
+ */
+function normalizeChatList(list) {
+  return Object.keys(list).reduce((acc, name) => {
+    // Convert { "ChatName": -11111 } to { "ChatName": { id: -11111, .... } }
+    if (typeof list[name] === 'number') {
+      acc[name] = {
+        id: list[name],
+        stickers: {
+          remove: false,
+          restrict: false,
+        },
+      }
+    }
+    else {
+      acc[name] = list[name]
+    }
+    return acc
+  }, {})
+}
+
+module.exports = {
+  validateChatList,
+  normalizeChatList,
+  InvalidChatlistError,
+}

--- a/src/lib/telegram-group.js
+++ b/src/lib/telegram-group.js
@@ -17,6 +17,11 @@ class TelegramGroup {
    */
   constructor(chatId, botInstance) {
     this.id = chatId
+    /**
+     * Options from .chatlist.json
+     * @type {{ stickers: { remove: boolean, restrict: boolean } }}
+     */
+    this.options = {}
     this.bot = botInstance
     this.telegram = this.bot.telegram
     this.debug = Debug(`rubot:lib:telegram-group:id#${chatId}`)
@@ -28,10 +33,29 @@ class TelegramGroup {
   }
 
   /**
+   * Options from .chatlist.json
+   * @param {{ stickers: Object }} options
+   */
+  setOptions(options) {
+    this.options = options
+  }
+
+  /**
    * @return {Promise<boolean>}
    */
   isBotAdmin() {
     return this.isAdmin(this.bot.context.botInfo)
+  }
+
+  /**
+   * Get settings of stickers in group
+   * @return {{ remove: boolean, restrict: boolean }}
+   */
+  getStickersOptions() {
+    return Object.assign({
+      remove: false,
+      restrict: false,
+    }, this.options.stickers)
   }
 
   /**


### PR DESCRIPTION
`.chatlist.json` now can have special options described in `chatlist.schema.json`. For VSCode added settings to autocomplete.

When `chat.options.stickers.remove` is `true` bot will autoremove stickers from chat.

When `chat.options.stickers.restrict` is `true` bot will restrict each user who send sticker to send stickers