### PR TITLE
remove !spam command after all

### DIFF
--- a/src/features/spam-hammer/index.js
+++ b/src/features/spam-hammer/index.js
@@ -57,7 +57,6 @@ async function handleSpamCommand({
     try {
       const hammer = getHammer()
 
-      await deleteMessage()
       const blacklistedList = await hammer.blacklistUser(spammer)
 
       try {
@@ -75,7 +74,13 @@ async function handleSpamCommand({
       }, keyboardUnspamUser({ banned: spammer }).extra())
       /** @see https://core.telegram.org/bots/api#forwardmessage */
 
-      await hammer.dropMessagesOf(spammer)
+      try {
+        await hammer.dropMessagesOf(spammer)
+      }
+      catch (error) {
+        debug('handleSpamCommand dropMessagesOfSpammer failed', error)
+      }
+      await deleteMessage()
 
       // TODO: search all entities in message (urls)
     }


### PR DESCRIPTION
before: admins should wait before all spam messages will deleted. And can't recognize when process
is failed
Now: !spam command not deleted immediatly, and delete it after spam deleted and spammer
banned